### PR TITLE
use setTimeout instead of setImmediate

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,7 @@ const pushView = async (key, view) => {
   await push()
 
   async function push() {
-    if (locks[key]) return setImmediate(async () => { await push() })
+    if (locks[key]) return setTimeout(async () => { await push() }, 0)
     locks[key] = true
 
     const views = await db.has(key)


### PR DESCRIPTION
`setImmediate` is  a non standard feature and the behavior is non stable. In the `src/utils.js` I have replaced the `setImmediate` function call with an this alternative

```js
setTimeout(async () => {
 await push()
}, 0)
```
