### PR TITLE
Move update-notifier -> dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "micro": "6.1.0",
     "micro-analytics-adapter-flat-file-db": "^1.0.3",
     "promise": "^7.1.1",
-    "shelljs": "^0.7.6"
+    "shelljs": "^0.7.6",
+    "update-notifier": "^1.0.3"
   },
   "devDependencies": {
     "async-to-gen": "^1.3.0",
@@ -37,8 +38,7 @@
     "babel-polyfill": "^6.20.0",
     "babel-preset-node6": "^11.0.0",
     "jest": "^18.1.0",
-    "request-promise": "^4.1.1",
-    "update-notifier": "^1.0.3"
+    "request-promise": "^4.1.1"
   },
   "execMap": {
     "js": "micro"


### PR DESCRIPTION
update-notifier is used as a dependency but is listed as a dev dependency. This moves it to be a dependency.